### PR TITLE
Seed phrase enhancements

### DIFF
--- a/hippius_sdk/cli_handlers.py
+++ b/hippius_sdk/cli_handlers.py
@@ -115,10 +115,19 @@ def create_client(args: Any) -> HippiusClient:
         needs_password = False
 
         # Check if this is one of the commands that needs a password
-        if command in ["store", "store-dir", "download", "delete", "delete-dir", "reconstruct"]:
+        if command in [
+            "store",
+            "store-dir",
+            "download",
+            "delete",
+            "delete-dir",
+            "reconstruct",
+        ]:
             needs_password = True
         # Special case for erasure-code - only needs password if we're publishing
-        elif command == "erasure-code" and not (hasattr(args, "no_publish") and args.no_publish):
+        elif command == "erasure-code" and not (
+            hasattr(args, "no_publish") and args.no_publish
+        ):
             needs_password = True
 
         # If this command doesn't need password access, set to empty string to skip prompting
@@ -702,7 +711,7 @@ async def handle_credits(
                 account_address = client.substrate_client._keypair.ss58_address
             else:
                 # Get the active account name and its address
-                from hippius_sdk.config import get_active_account, get_account_address
+                from hippius_sdk.config import get_account_address, get_active_account
 
                 active_account = get_active_account()
                 if active_account:
@@ -710,13 +719,23 @@ async def handle_credits(
                     if active_address:
                         account_address = active_address
                     else:
-                        error(f"Active account '{active_account}' does not have a valid address.")
-                        warning("Please provide an account address with '--account_address'")
+                        error(
+                            f"Active account '{active_account}' does not have a valid address."
+                        )
+                        warning(
+                            "Please provide an account address with '--account_address'"
+                        )
                         return 1
                 else:
-                    error("No account address provided, no active account set, and client has no keypair.")
-                    warning("Please provide an account address with '--account_address' or set an active account with:")
-                    log("  [bold green underline]hippius account switch <account_name>[/bold green underline]")
+                    error(
+                        "No account address provided, no active account set, and client has no keypair."
+                    )
+                    warning(
+                        "Please provide an account address with '--account_address' or set an active account with:"
+                    )
+                    log(
+                        "  [bold green underline]hippius account switch <account_name>[/bold green underline]"
+                    )
                     return 1
 
         credits = await client.substrate_client.get_free_credits(account_address)
@@ -3165,7 +3184,7 @@ async def handle_account_balance(
             account_address = client.substrate_client._keypair.ss58_address
         else:
             # Get the active account name and its address
-            from hippius_sdk.config import get_active_account, get_account_address
+            from hippius_sdk.config import get_account_address, get_active_account
 
             active_account = get_active_account()
             if active_account:
@@ -3173,12 +3192,20 @@ async def handle_account_balance(
                 if active_address:
                     account_address = active_address
                 else:
-                    error(f"Active account '{active_account}' does not have a valid address.")
-                    warning("Please provide an account address with '--account_address'")
+                    error(
+                        f"Active account '{active_account}' does not have a valid address."
+                    )
+                    warning(
+                        "Please provide an account address with '--account_address'"
+                    )
                     return 1
             else:
-                error("No account address provided, no active account set, and client has no keypair.")
-                warning("Please provide an account address with '--account_address' or set an active account with:")
+                error(
+                    "No account address provided, no active account set, and client has no keypair."
+                )
+                warning(
+                    "Please provide an account address with '--account_address' or set an active account with:"
+                )
                 log(
                     "  [bold green underline]hippius account switch <account_name>[/bold green underline]"
                 )

--- a/hippius_sdk/cli_handlers.py
+++ b/hippius_sdk/cli_handlers.py
@@ -102,20 +102,29 @@ def create_client(args: Any) -> HippiusClient:
     # Get substrate URL
     substrate_url = args.substrate_url if hasattr(args, "substrate_url") else None
 
-    # Skip password if we're doing erasure-code with --no-publish
-    # This avoids prompting for password when we don't need to interact with the blockchain
+    # Determine if we need to use password based on the command
+    # Only use password for: store, download, delete, erasure-code (unless --no-publish), reconstruct
     password = None
-    if (
-        hasattr(args, "command")
-        and args.command == "erasure-code"
-        and hasattr(args, "no_publish")
-        and args.no_publish
-    ):
-        # Don't need a password in this case
-        password = None
-    else:
-        # Use password from args if provided
-        password = args.password if hasattr(args, "password") else None
+
+    # First check if password is provided as an argument
+    if hasattr(args, "password") and args.password:
+        password = args.password
+    # Otherwise, decide based on the command
+    elif hasattr(args, "command"):
+        command = args.command
+        needs_password = False
+
+        # Check if this is one of the commands that needs a password
+        if command in ["store", "store-dir", "download", "delete", "delete-dir", "reconstruct"]:
+            needs_password = True
+        # Special case for erasure-code - only needs password if we're publishing
+        elif command == "erasure-code" and not (hasattr(args, "no_publish") and args.no_publish):
+            needs_password = True
+
+        # If this command doesn't need password access, set to empty string to skip prompting
+        if not needs_password:
+            # Use empty string to indicate "skip password prompt" to the config system
+            password = ""
 
     # Initialize client with provided parameters
     client = HippiusClient(
@@ -692,27 +701,22 @@ async def handle_credits(
             ):
                 account_address = client.substrate_client._keypair.ss58_address
             else:
-                # Try to get the default address
-                default_address = get_default_address()
-                if default_address:
-                    account_address = default_address
-                else:
-                    has_default = get_default_address() is not None
+                # Get the active account name and its address
+                from hippius_sdk.config import get_active_account, get_account_address
 
-                    error("No account address provided, and client has no keypair.")
-
-                    if has_default:
-                        warning(
-                            "Please provide an account address with '--account_address' or the default address may be invalid."
-                        )
+                active_account = get_active_account()
+                if active_account:
+                    active_address = get_account_address(active_account)
+                    if active_address:
+                        account_address = active_address
                     else:
-                        warning(
-                            "Please provide an account address with '--account_address' or set a default with:"
-                        )
-                        log(
-                            "  [bold green underline]hippius address set-default <your_account_address>[/bold green underline]"
-                        )
-
+                        error(f"Active account '{active_account}' does not have a valid address.")
+                        warning("Please provide an account address with '--account_address'")
+                        return 1
+                else:
+                    error("No account address provided, no active account set, and client has no keypair.")
+                    warning("Please provide an account address with '--account_address' or set an active account with:")
+                    log("  [bold green underline]hippius account switch <account_name>[/bold green underline]")
                     return 1
 
         credits = await client.substrate_client.get_free_credits(account_address)
@@ -3160,28 +3164,24 @@ async def handle_account_balance(
         ):
             account_address = client.substrate_client._keypair.ss58_address
         else:
-            # Try to get the default address
-            default_address = get_default_address()
-            if default_address:
-                account_address = default_address
-            else:
-                has_default = get_default_address() is not None
+            # Get the active account name and its address
+            from hippius_sdk.config import get_active_account, get_account_address
 
-                error("No account address provided, and client has no keypair.")
-
-                if has_default:
-                    warning(
-                        "Please provide an account address with '--account_address' or the default address may be invalid."
-                    )
+            active_account = get_active_account()
+            if active_account:
+                active_address = get_account_address(active_account)
+                if active_address:
+                    account_address = active_address
                 else:
-                    warning(
-                        "Please provide an account address with '--account_address' or set a default with:"
-                    )
-                    log(
-                        "  hippius address set-default <your_account_address>",
-                        style="bold blue",
-                    )
-
+                    error(f"Active account '{active_account}' does not have a valid address.")
+                    warning("Please provide an account address with '--account_address'")
+                    return 1
+            else:
+                error("No account address provided, no active account set, and client has no keypair.")
+                warning("Please provide an account address with '--account_address' or set an active account with:")
+                log(
+                    "  [bold green underline]hippius account switch <account_name>[/bold green underline]"
+                )
                 return 1
 
     # Get the account balance

--- a/hippius_sdk/client.py
+++ b/hippius_sdk/client.py
@@ -85,13 +85,15 @@ class HippiusClient:
         # Initialize Substrate client
         self.substrate_client = SubstrateClient(
             url=substrate_url,
-            seed_phrase=substrate_seed_phrase,
             password=seed_phrase_password,
             account_name=account_name,
         )
 
     async def upload_file(
-        self, file_path: str, encrypt: Optional[bool] = None
+        self,
+        file_path: str,
+        encrypt: Optional[bool] = None,
+        seed_phrase: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Upload a file to IPFS with optional encryption.
@@ -99,6 +101,7 @@ class HippiusClient:
         Args:
             file_path: Path to the file to upload
             encrypt: Whether to encrypt the file (overrides default)
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict[str, Any]: Dictionary containing file details including:
@@ -114,10 +117,15 @@ class HippiusClient:
             ValueError: If encryption is requested but not available
         """
         # Use the enhanced IPFSClient method directly with encryption parameter
-        return await self.ipfs_client.upload_file(file_path, encrypt=encrypt)
+        return await self.ipfs_client.upload_file(
+            file_path, encrypt=encrypt, seed_phrase=seed_phrase
+        )
 
     async def upload_directory(
-        self, dir_path: str, encrypt: Optional[bool] = None
+        self,
+        dir_path: str,
+        encrypt: Optional[bool] = None,
+        seed_phrase: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Upload a directory to IPFS with optional encryption.
@@ -125,6 +133,7 @@ class HippiusClient:
         Args:
             dir_path: Path to the directory to upload
             encrypt: Whether to encrypt files (overrides default)
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict[str, Any]: Dictionary containing directory details including:
@@ -141,10 +150,16 @@ class HippiusClient:
             ValueError: If encryption is requested but not available
         """
         # Use the enhanced IPFSClient method directly with encryption parameter
-        return await self.ipfs_client.upload_directory(dir_path, encrypt=encrypt)
+        return await self.ipfs_client.upload_directory(
+            dir_path, encrypt=encrypt, seed_phrase=seed_phrase
+        )
 
     async def download_file(
-        self, cid: str, output_path: str, decrypt: Optional[bool] = None
+        self,
+        cid: str,
+        output_path: str,
+        decrypt: Optional[bool] = None,
+        seed_phrase: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Download a file from IPFS with optional decryption.
@@ -154,6 +169,7 @@ class HippiusClient:
             cid: Content Identifier (CID) of the file to download
             output_path: Path where the downloaded file/directory will be saved
             decrypt: Whether to decrypt the file (overrides default)
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict[str, Any]: Dictionary containing download details including:
@@ -169,7 +185,9 @@ class HippiusClient:
             requests.RequestException: If the download fails
             ValueError: If decryption is requested but fails
         """
-        return await self.ipfs_client.download_file(cid, output_path, _=decrypt)
+        return await self.ipfs_client.download_file(
+            cid, output_path, _=decrypt, seed_phrase=seed_phrase
+        )
 
     async def cat(
         self,
@@ -177,6 +195,7 @@ class HippiusClient:
         max_display_bytes: int = 1024,
         format_output: bool = True,
         decrypt: Optional[bool] = None,
+        seed_phrase: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Get the content of a file from IPFS with optional decryption.
@@ -186,6 +205,7 @@ class HippiusClient:
             max_display_bytes: Maximum number of bytes to include in the preview
             format_output: Whether to attempt to decode the content as text
             decrypt: Whether to decrypt the file (overrides default)
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict[str, Any]: Dictionary containing content details including:
@@ -197,15 +217,22 @@ class HippiusClient:
                 - decrypted: Whether the file was decrypted
         """
         return await self.ipfs_client.cat(
-            cid, max_display_bytes, format_output, decrypt=decrypt
+            cid,
+            max_display_bytes,
+            format_output,
+            decrypt=decrypt,
+            seed_phrase=seed_phrase,
         )
 
-    async def exists(self, cid: str) -> Dict[str, Any]:
+    async def exists(
+        self, cid: str, seed_phrase: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
         Check if a CID exists on IPFS.
 
         Args:
             cid: Content Identifier (CID) to check
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict[str, Any]: Dictionary containing:
@@ -214,14 +241,15 @@ class HippiusClient:
                 - formatted_cid: Formatted version of the CID
                 - gateway_url: URL to access the content if it exists
         """
-        return await self.ipfs_client.exists(cid)
+        return await self.ipfs_client.exists(cid, seed_phrase=seed_phrase)
 
-    async def pin(self, cid: str) -> Dict[str, Any]:
+    async def pin(self, cid: str, seed_phrase: Optional[str] = None) -> Dict[str, Any]:
         """
         Pin a CID to IPFS to keep it available.
 
         Args:
             cid: Content Identifier (CID) to pin
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict[str, Any]: Dictionary containing:
@@ -230,7 +258,7 @@ class HippiusClient:
                 - formatted_cid: Formatted version of the CID
                 - message: Status message
         """
-        return await self.ipfs_client.pin(cid)
+        return await self.ipfs_client.pin(cid, seed_phrase=seed_phrase)
 
     def format_cid(self, cid: str) -> str:
         """
@@ -293,6 +321,7 @@ class HippiusClient:
         encrypt: Optional[bool] = None,
         max_retries: int = 3,
         verbose: bool = True,
+        seed_phrase: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Split a file using erasure coding, then upload the chunks to IPFS.
@@ -310,6 +339,7 @@ class HippiusClient:
             encrypt: Whether to encrypt the file before encoding (defaults to self.encrypt_by_default)
             max_retries: Maximum number of retry attempts for IPFS uploads
             verbose: Whether to print progress information
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             dict: Metadata including the original file info and chunk information
@@ -326,6 +356,7 @@ class HippiusClient:
             encrypt=encrypt,
             max_retries=max_retries,
             verbose=verbose,
+            seed_phrase=seed_phrase,
         )
 
     async def reconstruct_from_erasure_code(
@@ -335,6 +366,7 @@ class HippiusClient:
         temp_dir: str = None,
         max_retries: int = 3,
         verbose: bool = True,
+        seed_phrase: Optional[str] = None,
     ) -> Dict:
         """
         Reconstruct a file from erasure-coded chunks using its metadata.
@@ -345,6 +377,7 @@ class HippiusClient:
             temp_dir: Directory to use for temporary files (default: system temp)
             max_retries: Maximum number of retry attempts for IPFS downloads
             verbose: Whether to print progress information
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict: containing file reconstruction info.
@@ -359,6 +392,7 @@ class HippiusClient:
             temp_dir=temp_dir,
             max_retries=max_retries,
             verbose=verbose,
+            seed_phrase=seed_phrase,
         )
 
     async def store_erasure_coded_file(
@@ -373,6 +407,7 @@ class HippiusClient:
         verbose: bool = True,
         progress_callback: Optional[Callable[[str, int, int], None]] = None,
         publish: bool = True,
+        seed_phrase: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Erasure code a file, upload the chunks to IPFS, and store in the Hippius marketplace.
@@ -393,6 +428,7 @@ class HippiusClient:
             publish: Whether to publish to the blockchain (True) or just perform local
                     erasure coding without publishing (False). When False, no password
                     is needed for seed phrase access.
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             dict: Result including metadata CID and transaction hash (if published)
@@ -413,10 +449,14 @@ class HippiusClient:
             verbose=verbose,
             progress_callback=progress_callback,
             publish=publish,
+            seed_phrase=seed_phrase,
         )
 
     async def delete_file(
-        self, cid: str, cancel_from_blockchain: bool = True
+        self,
+        cid: str,
+        cancel_from_blockchain: bool = True,
+        seed_phrase: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Delete a file from IPFS and optionally cancel its storage on the blockchain.
@@ -424,6 +464,7 @@ class HippiusClient:
         Args:
             cid: Content Identifier (CID) of the file to delete
             cancel_from_blockchain: Whether to also cancel the storage request from the blockchain
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             Dict containing the result of the operation
@@ -431,13 +472,16 @@ class HippiusClient:
         Raises:
             RuntimeError: If deletion fails completely
         """
-        return await self.ipfs_client.delete_file(cid, cancel_from_blockchain)
+        return await self.ipfs_client.delete_file(
+            cid, cancel_from_blockchain, seed_phrase=seed_phrase
+        )
 
     async def delete_ec_file(
         self,
         metadata_cid: str,
         cancel_from_blockchain: bool = True,
         parallel_limit: int = 20,
+        seed_phrase: Optional[str] = None,
     ) -> bool:
         """
         Delete an erasure-coded file, including all its chunks in parallel.
@@ -446,6 +490,7 @@ class HippiusClient:
             metadata_cid: CID of the metadata file for the erasure-coded file
             cancel_from_blockchain: Whether to cancel storage from blockchain
             parallel_limit: Maximum number of concurrent deletion operations
+            seed_phrase: Optional seed phrase to use for blockchain interactions (uses config if None)
 
         Returns:
             True or false if failed.
@@ -454,5 +499,8 @@ class HippiusClient:
             RuntimeError: If deletion fails completely
         """
         return await self.ipfs_client.delete_ec_file(
-            metadata_cid, cancel_from_blockchain, parallel_limit
+            metadata_cid,
+            cancel_from_blockchain,
+            parallel_limit,
+            seed_phrase=seed_phrase,
         )

--- a/hippius_sdk/config.py
+++ b/hippius_sdk/config.py
@@ -380,7 +380,7 @@ def decrypt_seed_phrase(
     Decrypt the substrate seed phrase using password-based decryption.
 
     Args:
-        password: Optional password (if None, will prompt)
+        password: Optional password (if None, will prompt; if empty string, will skip password for read-only operations)
         account_name: Optional account name (if None, uses active account)
 
     Returns:
@@ -412,6 +412,12 @@ def decrypt_seed_phrase(
         print("Error: No encrypted seed phrase found or missing salt")
         return None
 
+    # Check if we're in skip-password mode (empty string)
+    # This is used for read-only operations that don't need blockchain interaction
+    if password == "":
+        # Don't print a message as it's confusing to the user
+        return None
+
     # Get password from user if not provided
     if password is None:
         password = getpass.getpass("Enter password to decrypt seed phrase: \n\n")
@@ -427,7 +433,8 @@ def get_seed_phrase(
     Get the substrate seed phrase from configuration, decrypting if necessary.
 
     Args:
-        password: Optional password for decryption (if None and needed, will prompt)
+        password: Optional password for decryption (if None and needed, will prompt;
+                if empty string, will skip decryption for read-only operations)
         account_name: Optional account name (if None, uses active account)
 
     Returns:
@@ -448,6 +455,11 @@ def get_seed_phrase(
 
     account_data = config["substrate"]["accounts"][name_to_use]
     is_encoded = account_data.get("seed_phrase_encoded", False)
+
+    # If password is an empty string, this indicates we're doing a read-only operation
+    # that doesn't require the seed phrase, so we can return None
+    if password == "" and is_encoded:
+        return None
 
     if is_encoded:
         return decrypt_seed_phrase(password, name_to_use)

--- a/hippius_sdk/ipfs.py
+++ b/hippius_sdk/ipfs.py
@@ -13,16 +13,8 @@ import uuid
 from typing import Any, Callable, Dict, List, Optional
 
 import httpx
-import requests
 
 from hippius_sdk.config import get_config_value, get_encryption_key
-from hippius_sdk.errors import (
-    HippiusAlreadyDeletedError,
-    HippiusFailedIPFSUnpin,
-    HippiusFailedSubstrateDelete,
-    HippiusIPFSConnectionError,
-    HippiusMetadataError,
-)
 from hippius_sdk.ipfs_core import AsyncIPFSClient
 from hippius_sdk.substrate import FileInput, SubstrateClient
 from hippius_sdk.utils import format_cid, format_size

--- a/tests/test_substrate.py
+++ b/tests/test_substrate.py
@@ -88,7 +88,7 @@ def test_init_with_seed_phrase(mock_substrate_interface, mock_keypair, mock_conf
         client = SubstrateClient(url=url)
         seed_phrase = "test seed phrase"
         client.set_seed_phrase(seed_phrase)
-        
+
         # Check set_seed_phrase was called correctly
         mock_set_seed_phrase.assert_called_once_with(seed_phrase)
 
@@ -206,7 +206,7 @@ async def test_storage_request(
     seed_phrase = "test seed phrase"
     client = SubstrateClient(url=url)
     client._substrate = mock_substrate
-    
+
     # Mock _ensure_keypair to simulate the seed phrase being used
     with patch.object(SubstrateClient, "_ensure_keypair") as mock_ensure_keypair:
         mock_ensure_keypair.return_value = True
@@ -247,7 +247,7 @@ async def test_storage_request(
 
     # Verify _ensure_keypair was called with the seed phrase
     mock_ensure_keypair.assert_called_once_with(seed_phrase)
-    
+
     mock_temp_file.write.assert_called_once_with(expected_json)
     mock_ipfs.upload_file.assert_called_once_with(mock_temp_file.name)
     mock_substrate.compose_call.assert_called_once()

--- a/tests/test_substrate_account.py
+++ b/tests/test_substrate_account.py
@@ -273,7 +273,9 @@ class TestSubstrateAccountExportImport:
                     mock_file.read.return_value = json.dumps(test_account)
 
                     # Mock get_all_config to return empty accounts to avoid name collision
-                    with patch("hippius_sdk.substrate.get_all_config") as mock_get_config:
+                    with patch(
+                        "hippius_sdk.substrate.get_all_config"
+                    ) as mock_get_config:
                         mock_get_config.return_value = {"substrate": {"accounts": {}}}
 
                         # Import the account
@@ -296,7 +298,9 @@ class TestSubstrateAccountExportImport:
                         )
                         mock_set_active.assert_called_once_with("imported_account")
                         # Verify set_seed_phrase was called with the test mnemonic
-                        mock_set_client_seed.assert_called_once_with(test_account["mnemonic"])
+                        mock_set_client_seed.assert_called_once_with(
+                            test_account["mnemonic"]
+                        )
 
     @patch("hippius_sdk.substrate.set_seed_phrase")
     @patch("hippius_sdk.substrate.set_active_account")
@@ -355,7 +359,10 @@ class TestSubstrateAccountExportImport:
                         result = client.import_account("test_import.json")
 
                         # Verify the result has a modified name
-                        assert result["name"] == "imported_account_imported_20230428_120000"
+                        assert (
+                            result["name"]
+                            == "imported_account_imported_20230428_120000"
+                        )
                         assert (
                             result["address"]
                             == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
@@ -372,7 +379,9 @@ class TestSubstrateAccountExportImport:
                             "imported_account_imported_20230428_120000"
                         )
                         # Verify set_seed_phrase was called with the test mnemonic
-                        mock_set_client_seed.assert_called_once_with(test_account["mnemonic"])
+                        mock_set_client_seed.assert_called_once_with(
+                            test_account["mnemonic"]
+                        )
 
     def test_import_account_invalid_format(self):
         """Test importing an account with invalid format."""

--- a/tests/test_substrate_account.py
+++ b/tests/test_substrate_account.py
@@ -43,28 +43,32 @@ class TestSubstrateAccountCreation:
                 )
                 mock_keypair_class.create_from_mnemonic.return_value = mock_keypair
 
-                # Create the account
-                result = client.create_account("test_account")
+                # We need to mock set_seed_phrase since our implementation now uses it
+                with patch.object(client, "set_seed_phrase") as mock_set_client_seed:
+                    # Create the account
+                    result = client.create_account("test_account")
 
-                # Verify the result
-                assert result["name"] == "test_account"
-                assert (
-                    result["address"]
-                    == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-                )
-                assert result["mnemonic"] == test_mnemonic
-                assert result["is_active"] is True
-                assert "creation_date" in result
+                    # Verify the result
+                    assert result["name"] == "test_account"
+                    assert (
+                        result["address"]
+                        == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+                    )
+                    assert result["mnemonic"] == test_mnemonic
+                    assert result["is_active"] is True
+                    assert "creation_date" in result
 
-                # Verify the mocks were called correctly
-                mock_generate.assert_called_once()
-                mock_keypair_class.create_from_mnemonic.assert_called_once_with(
-                    test_mnemonic
-                )
-                mock_set_seed.assert_called_once_with(
-                    test_mnemonic, encode=False, account_name="test_account"
-                )
-                mock_set_active.assert_called_once_with("test_account")
+                    # Verify the mocks were called correctly
+                    mock_generate.assert_called_once()
+                    mock_keypair_class.create_from_mnemonic.assert_called_once_with(
+                        test_mnemonic
+                    )
+                    mock_set_seed.assert_called_once_with(
+                        test_mnemonic, encode=False, account_name="test_account"
+                    )
+                    mock_set_active.assert_called_once_with("test_account")
+                    # Verify set_seed_phrase was called with the test mnemonic
+                    mock_set_client_seed.assert_called_once_with(test_mnemonic)
 
     @patch("hippius_sdk.substrate.set_seed_phrase")
     @patch("hippius_sdk.substrate.set_active_account")
@@ -96,33 +100,37 @@ class TestSubstrateAccountCreation:
                 )
                 mock_keypair_class.create_from_mnemonic.return_value = mock_keypair
 
-                # Create the account with encryption
-                test_password = "test_password"
-                result = client.create_account(
-                    "test_account", encode=True, password=test_password
-                )
+                # We need to mock set_seed_phrase since our implementation now uses it
+                with patch.object(client, "set_seed_phrase") as mock_set_client_seed:
+                    # Create the account with encryption
+                    test_password = "test_password"
+                    result = client.create_account(
+                        "test_account", encode=True, password=test_password
+                    )
 
-                # Verify the result
-                assert result["name"] == "test_account"
-                assert (
-                    result["address"]
-                    == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-                )
-                assert result["mnemonic"] == test_mnemonic
-                assert result["is_active"] is True
+                    # Verify the result
+                    assert result["name"] == "test_account"
+                    assert (
+                        result["address"]
+                        == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+                    )
+                    assert result["mnemonic"] == test_mnemonic
+                    assert result["is_active"] is True
 
-                # Verify the mocks were called correctly
-                mock_generate.assert_called_once()
-                mock_keypair_class.create_from_mnemonic.assert_called_once_with(
-                    test_mnemonic
-                )
-                mock_set_seed.assert_called_once_with(
-                    test_mnemonic,
-                    encode=True,
-                    password=test_password,
-                    account_name="test_account",
-                )
-                mock_set_active.assert_called_once_with("test_account")
+                    # Verify the mocks were called correctly
+                    mock_generate.assert_called_once()
+                    mock_keypair_class.create_from_mnemonic.assert_called_once_with(
+                        test_mnemonic
+                    )
+                    mock_set_seed.assert_called_once_with(
+                        test_mnemonic,
+                        encode=True,
+                        password=test_password,
+                        account_name="test_account",
+                    )
+                    mock_set_active.assert_called_once_with("test_account")
+                    # Verify set_seed_phrase was called with the test mnemonic
+                    mock_set_client_seed.assert_called_once_with(test_mnemonic)
 
     @patch("hippius_sdk.substrate.get_all_config")
     def test_create_account_name_exists(self, mock_get_config):
@@ -256,35 +264,39 @@ class TestSubstrateAccountExportImport:
             mock_keypair.ss58_address = test_account["address"]
             mock_keypair_class.create_from_mnemonic.return_value = mock_keypair
 
-            # Mock opening the file to return our test account data
-            with patch("builtins.open", create=True) as mock_open:
-                mock_file = MagicMock()
-                mock_open.return_value.__enter__.return_value = mock_file
-                mock_file.read.return_value = json.dumps(test_account)
+            # We need to mock set_seed_phrase since our implementation now uses it
+            with patch.object(client, "set_seed_phrase") as mock_set_client_seed:
+                # Mock opening the file to return our test account data
+                with patch("builtins.open", create=True) as mock_open:
+                    mock_file = MagicMock()
+                    mock_open.return_value.__enter__.return_value = mock_file
+                    mock_file.read.return_value = json.dumps(test_account)
 
-                # Mock get_all_config to return empty accounts to avoid name collision
-                with patch("hippius_sdk.substrate.get_all_config") as mock_get_config:
-                    mock_get_config.return_value = {"substrate": {"accounts": {}}}
+                    # Mock get_all_config to return empty accounts to avoid name collision
+                    with patch("hippius_sdk.substrate.get_all_config") as mock_get_config:
+                        mock_get_config.return_value = {"substrate": {"accounts": {}}}
 
-                    # Import the account
-                    result = client.import_account("test_import.json")
+                        # Import the account
+                        result = client.import_account("test_import.json")
 
-                    # Verify the result
-                    assert result["name"] == "imported_account"
-                    assert (
-                        result["address"]
-                        == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-                    )
-                    assert result["is_active"] is True
+                        # Verify the result
+                        assert result["name"] == "imported_account"
+                        assert (
+                            result["address"]
+                            == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+                        )
+                        assert result["is_active"] is True
 
-                    # Verify the mocks were called correctly
-                    mock_open.assert_called_once_with("test_import.json", "r")
-                    mock_set_seed.assert_called_once_with(
-                        test_account["mnemonic"],
-                        encode=False,
-                        account_name="imported_account",
-                    )
-                    mock_set_active.assert_called_once_with("imported_account")
+                        # Verify the mocks were called correctly
+                        mock_open.assert_called_once_with("test_import.json", "r")
+                        mock_set_seed.assert_called_once_with(
+                            test_account["mnemonic"],
+                            encode=False,
+                            account_name="imported_account",
+                        )
+                        mock_set_active.assert_called_once_with("imported_account")
+                        # Verify set_seed_phrase was called with the test mnemonic
+                        mock_set_client_seed.assert_called_once_with(test_account["mnemonic"])
 
     @patch("hippius_sdk.substrate.set_seed_phrase")
     @patch("hippius_sdk.substrate.set_active_account")
@@ -325,38 +337,42 @@ class TestSubstrateAccountExportImport:
             mock_keypair.ss58_address = test_account["address"]
             mock_keypair_class.create_from_mnemonic.return_value = mock_keypair
 
-            # Mock opening the file to return our test account data
-            with patch("builtins.open", create=True) as mock_open:
-                mock_file = MagicMock()
-                mock_open.return_value.__enter__.return_value = mock_file
-                mock_file.read.return_value = json.dumps(test_account)
+            # We need to mock set_seed_phrase since our implementation now uses it
+            with patch.object(client, "set_seed_phrase") as mock_set_client_seed:
+                # Mock opening the file to return our test account data
+                with patch("builtins.open", create=True) as mock_open:
+                    mock_file = MagicMock()
+                    mock_open.return_value.__enter__.return_value = mock_file
+                    mock_file.read.return_value = json.dumps(test_account)
 
-                # Patch datetime to get a deterministic name for the imported account
-                with patch("hippius_sdk.substrate.datetime") as mock_datetime:
-                    mock_datetime.datetime.now.return_value.strftime.return_value = (
-                        "20230428_120000"
-                    )
+                    # Patch datetime to get a deterministic name for the imported account
+                    with patch("hippius_sdk.substrate.datetime") as mock_datetime:
+                        mock_datetime.datetime.now.return_value.strftime.return_value = (
+                            "20230428_120000"
+                        )
 
-                    # Import the account - should rename to avoid collision
-                    result = client.import_account("test_import.json")
+                        # Import the account - should rename to avoid collision
+                        result = client.import_account("test_import.json")
 
-                    # Verify the result has a modified name
-                    assert result["name"] == "imported_account_imported_20230428_120000"
-                    assert (
-                        result["address"]
-                        == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
-                    )
-                    assert result["original_name"] == "imported_account"
+                        # Verify the result has a modified name
+                        assert result["name"] == "imported_account_imported_20230428_120000"
+                        assert (
+                            result["address"]
+                            == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+                        )
+                        assert result["original_name"] == "imported_account"
 
-                    # Verify the mocks were called correctly with the new name
-                    mock_set_seed.assert_called_once_with(
-                        test_account["mnemonic"],
-                        encode=False,
-                        account_name="imported_account_imported_20230428_120000",
-                    )
-                    mock_set_active.assert_called_once_with(
-                        "imported_account_imported_20230428_120000"
-                    )
+                        # Verify the mocks were called correctly with the new name
+                        mock_set_seed.assert_called_once_with(
+                            test_account["mnemonic"],
+                            encode=False,
+                            account_name="imported_account_imported_20230428_120000",
+                        )
+                        mock_set_active.assert_called_once_with(
+                            "imported_account_imported_20230428_120000"
+                        )
+                        # Verify set_seed_phrase was called with the test mnemonic
+                        mock_set_client_seed.assert_called_once_with(test_account["mnemonic"])
 
     def test_import_account_invalid_format(self):
         """Test importing an account with invalid format."""


### PR DESCRIPTION
Added optional `seed_phrase` param to functions that interact with the blockchain (to be used to inject seed phrase from s3 layer)
Remove password prompts for read-only operations while maintaining them for blockchain writes
Fixed account selection to properly use the active account instead of default address